### PR TITLE
Base progress bar component

### DIFF
--- a/packages/vue/index/components/base/ZrProgress.vue
+++ b/packages/vue/index/components/base/ZrProgress.vue
@@ -1,0 +1,54 @@
+<template>
+  <progress :max="maxValue" :value="currentValue"></progress>
+</template>
+
+<script>
+  /**
+   * A base component to display progress to user's
+   */
+
+  export default {
+    name: "ZrProgress",
+    props: {
+      /**
+       * Maximum value of the task that is being measured
+       */
+      maxValue: {
+        type: Number,
+        required: true,
+        default: 100
+      },
+      /**
+       * Current value to display in the progress bar
+       */
+      currentValue: {
+        type: Number,
+        required: true,
+        default: 0
+      }
+    },
+  }
+</script>
+
+<style scoped lang="scss">
+
+</style>
+
+<docs>
+  ### Examples
+
+  #### Default Progress Bar
+  ```jsx
+  <zr-progress></zr-progress>
+  ```
+
+  #### Max value 500, Current value 180
+  ```jsx
+  <zr-progress :max-value="500" :current-value="180"></zr-progress>
+  ```
+
+  #### Max value 500, Current value 480
+  ```jsx
+  <zr-progress :max-value="500" :current-value="480"></zr-progress>
+  ```
+</docs>


### PR DESCRIPTION
Adding a base progress bar component.  This almost seems unnecessary since it just leverages a native HTML element directly, however it will allow us to update any accessibility or fallback needs in a single place if those ever come up.  Sounds like this is ready go out of the box for now though:

![Screen Shot 2019-12-05 at 3 45 23 PM](https://user-images.githubusercontent.com/6816493/70280759-71bccd80-1776-11ea-839b-45574f010d7e.png)
