### PR TITLE
Aria Invalid Attribute for Form Elements

### DIFF
--- a/packages/vue/index/components/base/ZrInput.vue
+++ b/packages/vue/index/components/base/ZrInput.vue
@@ -6,6 +6,7 @@
            :name="name ? name : id"
            :value="value"
            :aria-label="!label ? placeholder : !label"
+           :aria-invalid="ariaInvalid"
            :placeholder="placeholder"
            :title="title"
            :required="required"
@@ -216,6 +217,19 @@
     label="No Label"
     :label-hidden="true"
     full
+  >
+  </ZrInput>
+  ```
+
+  ### Input `aria-invalid`
+  ```jsx
+  <ZrInput
+    placeholder="First Name"
+    id="first-name"
+    label="No Label"
+    :label-hidden="true"
+    :aria-invalid="true"
+    :invalid="true"
   >
   </ZrInput>
   ```

--- a/packages/vue/index/components/base/ZrSelect.vue
+++ b/packages/vue/index/components/base/ZrSelect.vue
@@ -6,6 +6,7 @@
                     :name="name ? name : id"
                     :value="value"
                     :class="{'input-sm': size === 'sm', 'input-lg': size === 'lg'}"
+                    :aria-invalid="ariaInvalid"
                     :required="required"
                     @change="updateValue">
                 <option v-if="placeholder" value="" disabled selected>{{placeholder}}</option>
@@ -159,5 +160,10 @@
     ### Invalid Select
     ```jsx
     <ZrSelect label="Required Select" :options="selectOptions" placeholder="Placeholder text" id="Preselected-select" :required="true" :invalid="true"></ZrSelect>
+    ```
+
+    ### Select `aria-invalid`
+    ```jsx
+    <ZrSelect label="Required Select" :options="selectOptions" placeholder="Placeholder text" id="Preselected-select" :aria-invalid="true" :invalid="true"></ZrSelect>
     ```
 </docs>

--- a/packages/vue/index/mixins/inputShared.js
+++ b/packages/vue/index/mixins/inputShared.js
@@ -69,6 +69,12 @@ export const inputShared = {
      */
     invalid: {
       type: Boolean
+    },
+    /**
+     * To indicate to the screen-reader whether the input is valid or invalid
+     */
+    ariaInvalid: {
+      type: Boolean
     }
   },
   mounted() {
@@ -86,4 +92,4 @@ export const inputShared = {
       };
     }
   }
-}
+};


### PR DESCRIPTION
### Summary

Added `aria-invalid` prop for when input is invalid. See select and input components.

### Screenshot
![Screen Shot 2019-12-09 at 3 03 27 PM](https://user-images.githubusercontent.com/8801287/70477087-4ba86d80-1a95-11ea-94eb-5283e8302ab3.png)
![Screen Shot 2019-12-09 at 3 03 52 PM](https://user-images.githubusercontent.com/8801287/70477089-4d723100-1a95-11ea-8a31-cfe3b7b1a4d0.png)
