### PR TITLE
Btn link tweak

### DIFF
--- a/packages/vue/index/components/base/ZrButton.vue
+++ b/packages/vue/index/components/base/ZrButton.vue
@@ -83,18 +83,18 @@
         default: false
       },
       /**
-       * Link to follow on click. Renders an <a> instead of <button>
+       * Path to follow on click.  Renders a link element instead of button
        */
-      href: {
+      linkPath: {
         type: String,
         default: null
       },
       /**
-       * Path to follow on click.  Renders <router-link> or <nuxt-link> (if nuxt prop is true) instead of <button>
+       * Defines whether this is an external link.  If true, renders an 'a' tag.  If false, renders router-link or nuxt-link (if supporting "to" prop exists)
        */
-      to: {
-        type: String,
-        default: null
+      externalLink: {
+        type: Boolean,
+        default: false
       },
       /**
        * Whether to render <nuxt-link> instead of <router-link> when using the 'to' prop
@@ -128,25 +128,25 @@
         ];
       },
       componentType() {
-        if (this.to) {
+        if (this.linkPath) {
+          if (this.externalLink) {
+            return 'a'
+          }
           return this.nuxt ? 'nuxt-link' : 'router-link'
-        } else if (this.href) {
-          return 'a'
         } else {
           return 'button'
         }
       },
-      finalTarget() {
-        return this.href ? this.target : null
-      },
       btnLinkProps() {
         const linkProps = {};
 
-        if (this.to) {
-          linkProps.to = this.to;
-        } else if (this.href) {
-          linkProps.href = this.href;
-          linkProps.target = this.finalTarget
+        if (this.linkPath) {
+          if (this.externalLink) {
+            linkProps.href = this.linkPath;
+            linkProps.target = this.target
+          } else {
+            linkProps.to = this.linkPath;
+          }
         }
 
         return linkProps
@@ -330,8 +330,8 @@
     #### Button Link Types
     ```jsx
     <ZrButton style="margin-bottom: 10px">Button</ZrButton>
-    <ZrButton href="www.google.com" style="margin-bottom: 10px">Standard Link</ZrButton>
-    <ZrButton to="/product/path" style="margin-bottom: 10px">Router Link</ZrButton>
-    <ZrButton to="/product/path" nuxt>Nuxt Link</ZrButton>
+    <ZrButton link-path="www.google.com" external-link style="margin-bottom: 10px">Standard Link</ZrButton>
+    <ZrButton link-path="/product/path" style="margin-bottom: 10px">Router Link</ZrButton>
+    <ZrButton link-path="/product/path" nuxt>Nuxt Link</ZrButton>
     ```
 </docs>

--- a/packages/vue/index/components/base/ZrButton.vue
+++ b/packages/vue/index/components/base/ZrButton.vue
@@ -3,9 +3,7 @@
             :is="componentType"
             :class="btnClass"
             :type="type"
-            :href="href"
-            :to="to"
-            :target="finalTarget"
+            v-bind="btnLinkProps"
             :title="title"
             :disabled="disabled">
         <span class="label">
@@ -140,7 +138,19 @@
       },
       finalTarget() {
         return this.href ? this.target : null
-      }
+      },
+      btnLinkProps() {
+        const linkProps = {};
+
+        if (this.to) {
+          linkProps.to = this.to;
+        } else if (this.href) {
+          linkProps.href = this.href;
+          linkProps.target = this.finalTarget
+        }
+
+        return linkProps
+      },
     },
   }
 </script>


### PR DESCRIPTION
Tweak to how link related props are passed to the component...passing `href` as null for <nuxt-link>s was messing with how the resulting link was rendered.  Still worked, but it messed up accessibility.  This fixes that, by only passing the relevant link props for the proper link type, and no link props at all when its just a button