### PR TITLE
Hero Banner cleanup

### DIFF
--- a/packages/vue/index/components/base/ZrImage.vue
+++ b/packages/vue/index/components/base/ZrImage.vue
@@ -1,8 +1,7 @@
 <template>
   <div>
     <img v-if="lazy" v-lazy :data-src="imageSrc"
-         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
-         :alt="altText" :class="imageClass" class="lazy-image"/>
+         :src="defaultImage" :alt="altText" :class="[imageClass, {'fade-image': fade}]" />
     <img v-else :src="imageSrc" :alt="altText" :class="imageClass"/>
     <noscript inline-template>
       <img :src="imageSrc" :alt="altText" :class="imageClass"/>
@@ -55,6 +54,13 @@
       fade: {
         type: Boolean,
         default: true
+      },
+      /**
+       * Default image to show
+       */
+      defaultImage: {
+        type: String,
+        default: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
       }
     },
   }
@@ -63,6 +69,15 @@
 <style scoped lang="scss">
   img {
     width: 100%;
+
+    &.lazy-image.fade-image {
+      opacity: 0;
+      transition: opacity 0.25s ease-out;
+
+      &.img-loaded {
+        opacity: 1;
+      }
+    }
   }
 </style>
 

--- a/packages/vue/index/components/base/ZrPicture.vue
+++ b/packages/vue/index/components/base/ZrPicture.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :class="{'image-fill': fill}">
     <picture v-if="lazy" v-lazy>
       <source :data-src="desktopImg" :media="breakpointQuery"
               srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="/>
@@ -65,6 +65,13 @@
         type: Boolean,
         default: true
       },
+      /**
+       * Whether or not the image should fill its parent container
+       */
+      fill: {
+        type: Boolean,
+        default: false
+      }
     },
     computed: {
       breakpointQuery() {
@@ -75,6 +82,17 @@
 </script>
 
 <style scoped lang="scss">
+  .image-fill {
+    width: 100%;
+    height: 100%;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
   picture {
     width: 100%;
     display: block;

--- a/packages/vue/index/components/base/ZrPicture.vue
+++ b/packages/vue/index/components/base/ZrPicture.vue
@@ -1,10 +1,8 @@
 <template>
-  <div :class="{'image-fill': fill}">
+  <div>
     <picture v-if="lazy" v-lazy>
-      <source :data-src="desktopImg" :media="breakpointQuery"
-              srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="/>
-      <img :data-src="mobileImg" :alt="altText"
-           src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="/>
+      <source :data-src="desktopImg" :media="breakpointQuery" :srcset="defaultImage">
+      <img :data-src="mobileImg" :alt="altText" :src="defaultImage" :class="{'fade-image': fade}" />
     </picture>
     <picture v-else>
       <source :srcset="desktopImg" :media="breakpointQuery"/>
@@ -20,7 +18,6 @@
 </template>
 
 <script>
-
   import '../../directives/lazyLoad'
 
   /**
@@ -66,11 +63,18 @@
         default: true
       },
       /**
-       * Whether or not the image should fill its parent container
+       * Whether or not to fade the image in if/when lazy loaded
        */
-      fill: {
+      fade: {
         type: Boolean,
-        default: false
+        default: true
+      },
+      /**
+       * Default image to show
+       */
+      defaultImage: {
+        type: String,
+        default: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
       }
     },
     computed: {
@@ -82,25 +86,18 @@
 </script>
 
 <style scoped lang="scss">
-  .image-fill {
-    width: 100%;
-    height: 100%;
-
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-  }
-
-  picture {
-    width: 100%;
-    display: block;
-  }
-
   img {
     display: block;
     width: 100%;
+
+    &.lazy-image.fade-image {
+      opacity: 0;
+      transition: opacity 0.25s ease-out;
+
+      &.img-loaded {
+        opacity: 1;
+      }
+    }
   }
 </style>
 

--- a/packages/vue/index/components/patterns/ZrHeroBanner.vue
+++ b/packages/vue/index/components/patterns/ZrHeroBanner.vue
@@ -59,48 +59,50 @@
 </script>
 
 <style scoped lang="scss">
-    @import '../../styles/imports';
+  @import '../../styles/imports';
 
-    .hero-banner {
-        position: relative;
+  .hero-banner {
+    position: relative;
+    width: 100%;
+  }
+
+  /deep/ img {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .hero-content-wrapper {
+    position: relative;
+    display: flex;
+    min-height: 30vw;
+    padding: $margin-smedium;
+
+    @media (min-width: $screen-md) {
+      padding: $margin-medium;
     }
 
-    .hero-content-wrapper {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-
-        &.center {
-            justify-content: center;
-        }
-
-        &.right {
-            justify-content: flex-end;
-        }
-
-        &.middle {
-            align-items: center;
-        }
-
-        &.bottom {
-            align-items: flex-end;
-        }
+    @media (min-width: $screen-lg) {
+      padding: $margin-large;
     }
 
-    .hero-content {
-        padding: $margin-smedium;
-
-        @media (min-width: $screen-md) {
-            padding: $margin-medium;
-        }
-
-        @media (min-width: $screen-lg) {
-            padding: $margin-large;
-        }
+    &.center {
+        justify-content: center;
     }
+
+    &.right {
+        justify-content: flex-end;
+    }
+
+    &.middle {
+        align-items: center;
+    }
+
+    &.bottom {
+        align-items: flex-end;
+    }
+  }
 </style>
 
 <docs>
@@ -112,7 +114,7 @@
                  :mobile-img="images.banner_image.mobile.url"
                  alt-text="Text about the image"
                  class="light-text">
-        <h1>Hi I am a Title</h1>
+        <h2>Hi I am a Title</h2>
         <h3>I am a subtitle</h3>
     </ZrHeroBanner>
     ```
@@ -125,9 +127,9 @@
                  vertical-position="bottom"
                  horizontal-position="right"
                  class="light-text">
-        <h1>Hi I am a Title</h1>
+        <h2>Hi I am a Title</h2>
         <h3>I am a subtitle</h3>
-        <ZrButton :label="'Learn More'" size="sm" theme="action" style="margin-top: 20px"></ZrButton>
+        <ZrButton size="sm" theme="action" style="margin-top: 20px">Learn More</ZrButton>
     </ZrHeroBanner>
     ```
 </docs>

--- a/packages/vue/index/directives/lazyLoad.js
+++ b/packages/vue/index/directives/lazyLoad.js
@@ -29,7 +29,7 @@ Vue.directive('lazy', function (el, binding, vnode) {
     const observerOptions = {
       disableFade: directiveProperties.disableFade ? directiveProperties.disableFade : false,
       root: directiveProperties.root ? directiveProperties.root : null,
-      rootMargin: directiveProperties.rootMargin ? directiveProperties.rootMargin : '0px 0px 500px 0px',
+      rootMargin: directiveProperties.rootMargin ? directiveProperties.rootMargin : '500px',
       threshold: directiveProperties.threshold ? directiveProperties.threshold : 0
     };
 


### PR DESCRIPTION
Refactoring the HeroBanner to have height based upon the content (and padding), with image positioned to fit in the background.  Using the image to prop open the container with content displayed over the top created a lot of issues in the real project.  The hero content now has a single min height value, which can be extended/customized wherever it gets used

Also included some cleanup of the ZrPicture and ZrImage components (defaultImage props, fade prop, default lazy load fading, etc)