### PR TITLE
Intersection updates

### DIFF
--- a/packages/vue/index/components/base/ZrPicture.vue
+++ b/packages/vue/index/components/base/ZrPicture.vue
@@ -1,22 +1,24 @@
 <template>
   <div>
-    <picture v-if="lazy" v-lazy="{rootMargin: rootMargin}">
-      <source v-if="desktopImg" :data-src="desktopImg" :media="breakpointQueryDesktop" :srcset="defaultImage">
-      <source v-if="tabletImg" :data-src="tabletImg" :media="breakpointQueryTablet" :srcset="defaultImage">
-      <img :data-src="mobileImg" :alt="altText" :src="defaultImage" :class="{'fade-image': fade}" :style="fadeStyle" />
-    </picture>
+    <template v-if="lazy">
+      <picture v-lazy="{rootMargin: rootMargin}">
+        <source v-if="desktopImg" :data-src="desktopImg" :media="breakpointQueryDesktop" :srcset="defaultImage">
+        <source v-if="tabletImg" :data-src="tabletImg" :media="breakpointQueryTablet" :srcset="defaultImage">
+        <img :data-src="mobileImg" :alt="altText" :src="defaultImage" :class="{'fade-image': fade}" :style="fadeStyle" />
+      </picture>
+      <noscript inline-template>
+        <picture>
+          <source v-if="desktopImg" :srcset="desktopImg" :media="breakpointQueryDesktop"/>
+          <source v-if="tabletImg" :srcset="tabletImg" :media="breakpointQueryTablet"/>
+          <img :src="mobileImg" :alt="altText" />
+        </picture>
+      </noscript>
+    </template>
     <picture v-else>
-      <source v-if="desktopImg" :srcset="desktopImg" :media="breakpointQueryDesktop"/>
-      <source v-if="tabletImg" :srcset="tabletImg" :media="breakpointQueryTablet"/>
+      <source v-if="desktopImg" :srcset="desktopImg" :media="breakpointQueryDesktop" />
+      <source v-if="tabletImg" :srcset="tabletImg" :media="breakpointQueryTablet" />
       <img :src="mobileImg" :alt="altText" />
     </picture>
-    <noscript inline-template>
-      <picture>
-        <source v-if="desktopImg" :srcset="desktopImg" :media="breakpointQueryDesktop"/>
-        <source v-if="tabletImg" :srcset="tabletImg" :media="breakpointQueryTablet"/>
-        <img :src="mobileImg" :alt="altText" />
-      </picture>
-    </noscript>
   </div>
 </template>
 

--- a/packages/vue/index/components/utility/ZrIntersection.vue
+++ b/packages/vue/index/components/utility/ZrIntersection.vue
@@ -48,7 +48,7 @@
     mounted() {
       const intersectionOptions = {
         rootMargin: this.rootMargin,
-        threshold: this.threshold
+        threshold: Number(this.threshold)
       };
 
       this.observer = new IntersectionObserver(entries => {


### PR DESCRIPTION
Updates to ZrIntersection and ZrPicture that clean up the lazy loading and intersection options.  There were two issues with using these components on Yeti, where the intersection observer was failing at mobile due to the Threshold not being a number.  In addition, I believe the <noscript> in the ZrPicture should only render if it is also a lazy image.