### PR TITLE
Update to currency component

### DIFF
--- a/packages/vue/index/components/base/ZrCurrency.vue
+++ b/packages/vue/index/components/base/ZrCurrency.vue
@@ -43,7 +43,7 @@
     computed: {
       formattedPrice() {
         const price = new Intl.NumberFormat(this.locale, { style: 'currency', currency: this.currencyCode }).format(this.value);
-        return this.decimals ? price : price.replace(/(\.[0-9]*?)0+/g, "");
+        return this.decimals ? price : price.replace(/(\.[0-9]*?)[0-9]+/g, "");
       }
     }
   }
@@ -75,7 +75,7 @@
   ```jsx
   <zr-currency :value="1234567" currency-code="CAD" locale="ca-FR" :style="{display: 'block'}"></zr-currency>
   <zr-currency :value="1234567" currency-code="JPY" locale="ja-JP" :style="{display: 'block'}"></zr-currency>
-  <zr-currency :value="1234567.00" currency-code="EUR" :style="{display: 'block'}" :decimals="false"></zr-currency>
+  <zr-currency :value="1234567.99" currency-code="EUR" :style="{display: 'block'}" :decimals="false"></zr-currency>
   ```
 </docs>
 

--- a/packages/vue/index/components/base/ZrCurrency.vue
+++ b/packages/vue/index/components/base/ZrCurrency.vue
@@ -31,11 +31,19 @@
       locale: {
         type: String,
         default: 'en'
+      },
+      /**
+       * Whether or not to display decimals at the end of the currency value
+       */
+      decimals: {
+        type: Boolean,
+        default: true
       }
     },
     computed: {
       formattedPrice() {
-        return new Intl.NumberFormat(this.locale, { style: 'currency', currency: this.currencyCode}).format(this.value)
+        const price = new Intl.NumberFormat(this.locale, { style: 'currency', currency: this.currencyCode }).format(this.value);
+        return this.decimals ? price : price.replace(/(\.[0-9]*?)0+/g, "");
       }
     }
   }
@@ -53,6 +61,11 @@
   <zr-currency :value="188"></zr-currency>
   ```
 
+  #### No decimals price display
+  ```jsx
+  <zr-currency :value="188.50" :decimals="false"></zr-currency>
+  ```
+
   #### Price with cents
   ```jsx
   <zr-currency :value="188.95"></zr-currency>
@@ -62,7 +75,7 @@
   ```jsx
   <zr-currency :value="1234567" currency-code="CAD" locale="ca-FR" :style="{display: 'block'}"></zr-currency>
   <zr-currency :value="1234567" currency-code="JPY" locale="ja-JP" :style="{display: 'block'}"></zr-currency>
-  <zr-currency :value="1234567" currency-code="EUR" :style="{display: 'block'}"></zr-currency>
+  <zr-currency :value="1234567.00" currency-code="EUR" :style="{display: 'block'}" :decimals="false"></zr-currency>
   ```
 </docs>
 


### PR DESCRIPTION
### SUMMARY

This adds a prop to display decimals or not to display decimals at the end of the formatted currency. I didn't see an option to do this with `Int.NumberFormat`, so it got regexed.

### Screenshot

![Screen Shot 2020-04-17 at 12 10 36 PM](https://user-images.githubusercontent.com/8801287/79600842-0af4dc80-80a5-11ea-8528-2975ad22f155.png)
