### PR TITLE
ZrIntersection updates

### DIFF
--- a/packages/vue/index/components/utility/ZrIntersection.vue
+++ b/packages/vue/index/components/utility/ZrIntersection.vue
@@ -45,16 +45,13 @@
       return {
         observer: null,
         previousY: 0,
-        previousRatio: 0
+        previousRatio: 0,
+        intersected: false
       }
     },
     computed: {
       cleanThresholdValue() {
-        if (this.threshold.includes(',')) {
-          const thresholdValues = this.threshold.split(',');
-          return thresholdValues.map(item => item);
-        }
-        return this.threshold;
+        return this.threshold.includes(',') ? this.threshold.split(',') : this.threshold;
       }
     },
     mounted() {
@@ -86,6 +83,7 @@
           }
 
           if (entry.isIntersecting) {
+            this.intersected = true;
             //console.log(intersectionObject);
             this.$emit('intersected', intersectionObject);
             if (this.once) {
@@ -96,9 +94,11 @@
           const downBoundaryCase = intersectionObject.scrollDirection === 'down' && !intersectionObject.entering && !intersectionObject.top;
           const upBoundaryCase = intersectionObject.scrollDirection === 'up' && !intersectionObject.entering && intersectionObject.top;
 
-          if (downBoundaryCase || upBoundaryCase) {
-            //console.log(intersectionObject);
-            this.$emit('intersected', intersectionObject);
+          if (this.intersected) {
+            if (downBoundaryCase || upBoundaryCase) {
+              //console.log(intersectionObject);
+              this.$emit('intersected', intersectionObject);
+            }
           }
 
           this.previousY = currentY;


### PR DESCRIPTION
Beefing up the ZrIntersection component to emit data about scrollDirection, whether its entering or leaving, and if its the top or bottom intersecting.  This should allow us to do a lot more with this component, and immediately so on Yeti.

Here is a screenshot of the object that gets emitted as the event payload, which contains all the information we need.  This screenshot is of console logs showing that event for an object that was scrolled down through the viewport and then back up through the viewport:
<img width="362" alt="Screen Shot 2020-05-07 at 1 44 56 AM" src="https://user-images.githubusercontent.com/6816493/81267868-64955a80-9004-11ea-89d3-c5eafcf82cc2.png">

