### PR TITLE
ZrIntersection Threshold Fix

### DIFF
--- a/packages/vue/index/components/utility/ZrIntersection.vue
+++ b/packages/vue/index/components/utility/ZrIntersection.vue
@@ -51,7 +51,8 @@
     },
     computed: {
       cleanThresholdValue() {
-        return this.threshold.includes(',') ? this.threshold.split(',') : this.threshold;
+        const thresholdArray = this.threshold.includes(',') && this.threshold.split(',').map(item => Number(item));
+        return thresholdArray || Number(this.threshold);
       }
     },
     mounted() {
@@ -136,7 +137,7 @@
     ```jsx
     let rootMarginLabel = 'not yet';
 
-    <ZrIntersection style="margin-top: 20vh" @intersected="rootMarginLabel = 'true'" rootMargin="-200px">
+    <ZrIntersection style="margin-top: 100vh" @intersected="rootMarginLabel = 'true'" rootMargin="0px 0px -200px 0px">
         <h2>Intersection: {{rootMarginLabel}}</h2>
     </ZrIntersection>
     ```


### PR DESCRIPTION
Fixing the format of threshold values so it doesn’t break the polyfill.  I ran into this issue before and fixed it, but then in my last round of updates I stupidly reintroduced the problem.  Basically, in the Nuxt projects we load an intersectionObserver polyfill so that it works in IE and certain mobile browsers.  And if that polyfill encounters a threshold option value that is not strictly a number, then it chokes the site.  

So this PR makes sure that our threshold values are always cast as numbers (or array of numbers).  Its tough because that polyfill doesn't exist in this UI Pantry.