### PR TITLE
Re-writing js files in es-5 syntax

### DIFF
--- a/packages/vue/index/directives/lazyLoad.js
+++ b/packages/vue/index/directives/lazyLoad.js
@@ -26,7 +26,7 @@ Vue.directive('lazy', function (el, binding, vnode) {
     let directiveProperties = binding.value ? binding.value : {};
 
     // set observer options from directive binding if available, otherwise set defaults
-    const observerOptions = {
+    var observerOptions = {
       disableFade: directiveProperties.disableFade ? directiveProperties.disableFade : false,
       root: directiveProperties.root ? directiveProperties.root : null,
       rootMargin: directiveProperties.rootMargin ? directiveProperties.rootMargin : '400px',
@@ -66,9 +66,9 @@ Vue.directive('lazy', function (el, binding, vnode) {
 
     function loadSrc(element, observerOptions) {
 
-      const videoTag = element.tagName === 'VIDEO';
-      const loadingClass = videoTag ? 'video-loading' : 'img-loading';
-      const loadedClass = videoTag  ? 'video-loaded' : 'img-loaded';
+      var videoTag = element.tagName === 'VIDEO';
+      var loadingClass = videoTag ? 'video-loading' : 'img-loading';
+      var loadedClass = videoTag  ? 'video-loaded' : 'img-loaded';
 
       if (observerOptions.disableFade) {
         element.classList.add('no-fade');
@@ -147,8 +147,8 @@ Vue.directive('lazy', function (el, binding, vnode) {
     function initObserver(observerOptions) {
 
       // create observer instance
-      const observer = new IntersectionObserver(((entries, observer) => {
-        entries.forEach((entry) => {
+      var observer = new IntersectionObserver((function(entries, observer) {
+        entries.forEach(function(entry) {
           if (entry.isIntersecting) {
             const intersectingElement = entry.target;
             loadElement(intersectingElement, observerOptions);

--- a/packages/vue/index/mixins/inputShared.js
+++ b/packages/vue/index/mixins/inputShared.js
@@ -79,17 +79,17 @@ export const inputShared = {
     }
 
   },
-  mounted() {
+  mounted: function() {
     if (this.validationMessage) {
-      const input = document.getElementById(this.id);
-      input.oninvalid = (e) => {
-        const el = e.target;
+      var input = document.getElementById(this.id);
+      input.oninvalid = function(e) {
+        var el = e.target;
         el.setCustomValidity('');
         if (!el.validity.valid) {
           el.setCustomValidity(this.validationMessage);
         }
       };
-      input.oninput = (e) => {
+      input.oninput = function(e) {
         e.target.setCustomValidity('');
       };
     }

--- a/packages/vue/index/mixins/lazyLoadShared.js
+++ b/packages/vue/index/mixins/lazyLoadShared.js
@@ -42,7 +42,7 @@ export const lazyLoadShared = {
     }
   },
   computed: {
-    fadeStyle() {
+    fadeStyle: function() {
       return `transition: opacity ${this.fadeDuration}s ${this.fadeEasing}`
     }
   }

--- a/packages/vue/index/package.json
+++ b/packages/vue/index/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zaneray/vue-components",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
There is an issue with the way that Nuxt pulls in components from this package.  This package exposes raw Vue components.  This was based off of several examples of how to publish vue components to NPM for usage across many projects.  

This works totally fine, however by default Nuxt does not transpile any dependencies that get imported, which is needed for our Base Project sites to work in IE11 and early versions of Edge.  Edge has since totally changed to a Chromium based browser, so there are no issues with the modern version of it.  Really this is an attempt to get our Base Project working in old legacy browsers: IE11 and early Edge versions.  Those aren't a huge concern of our customers, but still need to be supported out of the box.

The better long term solution is to change our component packaging strategy by using a tool like Rollup.js to fully transpile our components and js files before they get published to NPM.  I have a branch working on this, but it doesn't look like it will be complete anytime soon.  In the base project I have a branch that sets the nuxt.config to explicitly transpile anything that comes from the @zaneray/vue-components directory, but there is still an issue because some components import the lazy directive or other js mixins that don't get transpiled.  

So, this branch refactors those few JS files to have es5 syntax.  I'm fairly certain this will solve the problem for us short term, but in order to test I need to publish this branch to NPM and test in the Base Project on a windows VM.