### PR TITLE
ZrPicture Load Event

### DIFF
--- a/packages/vue/index/components/base/ZrPicture.vue
+++ b/packages/vue/index/components/base/ZrPicture.vue
@@ -168,4 +168,18 @@
   />
   ```
 
+  #### Basic Picture with lazy loading emitted event, mobile image and tablet
+  ```jsx
+
+  const loadPicture = () => console.log('load image');
+  const pictureLoaded = () => console.log('image loaded');
+
+  <ZrPicture :mobile-img="images.banner_image.mobile.url"
+             :tablet-img="images.banner_image.half.url"
+             :alt-text="images.banner_image.alt"
+             @load="loadPicture"
+             @loaded="pictureLoaded"
+  />
+  ```
+
 </docs>

--- a/packages/vue/index/directives/lazyLoad.js
+++ b/packages/vue/index/directives/lazyLoad.js
@@ -72,6 +72,8 @@ function loadSrc(element, observerOptions, vnode) {
 
 function loadElement(element, observerOptions, vnode) {
 
+  vnode.context.$emit('load');
+
   // -----------------------------------------------------------
   // case IMAGE || VIDEO tag
   // -----------------------------------------------------------
@@ -136,8 +138,6 @@ function bind(el, binding, vnode) {
 
   // set transparent image base 64 before image is loaded
   // el.setAttribute('src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
-
-  vnode.context.$emit('load');
 
   // attach initial class to lazy loaded <img> tag
   if (el.tagName === 'IMG') {

--- a/packages/vue/index/directives/lazyLoad.js
+++ b/packages/vue/index/directives/lazyLoad.js
@@ -137,6 +137,8 @@ function bind(el, binding, vnode) {
   // set transparent image base 64 before image is loaded
   // el.setAttribute('src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
 
+  vnode.context.$emit('load');
+
   // attach initial class to lazy loaded <img> tag
   if (el.tagName === 'IMG') {
     // tag lazy loaded image


### PR DESCRIPTION
### SUMMARY

This adds a load event to emit when the picture/image/video begins the load process. This allow for us to listen for when asset begins loading and when it completes the load cycle.

##### Custom Events

```
@load="loadStart"
@loaded="loadComplete"
```

### SCREENSHOT

<img width="499" alt="Screen Shot 2020-08-17 at 12 07 09 PM" src="https://user-images.githubusercontent.com/8801287/90429073-3eab3780-e082-11ea-88a9-4e5d6fb28311.png">

![Screen Shot 2020-08-17 at 12 07 23 PM](https://user-images.githubusercontent.com/8801287/90429077-410d9180-e082-11ea-8953-e1e7425ed3fc.png)

