### PR TITLE
Feature - Readonly Checkboxes

### DIFF
--- a/packages/vue/index/components/base/ZrCheckbox.vue
+++ b/packages/vue/index/components/base/ZrCheckbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="checkbox">
+    <div class="checkbox" :class="{ readonly: readonly, checked: selected}">
         <input type="checkbox"
                :name="name"
                :id="id"
@@ -8,6 +8,7 @@
                @change="inputChanged($event)"
                v-bind="$attrs"
                :disabled="disabled"
+               :readonly="readonly"
         />
         <label :for="id">{{label}}</label>
     </div>
@@ -43,8 +44,10 @@
     },
     methods: {
       inputChanged($event) {
-        this.$emit('change', this.value);
-        this.$emit('changeEvent', $event);
+        if (!this.readonly) {
+          this.$emit('change', this.value);
+          this.$emit('changeEvent', $event);
+        }
       }
     }
   }
@@ -63,10 +66,24 @@
         margin: 0;
         padding: 0;
 
+        .readonly.checked & + label {
+            &:after {
+                opacity: 1;
+                transform: rotate(-50deg) scale(1);
+            }
+        }
+
         &:checked + label {
             &:after {
                 opacity: 1;
                 transform: rotate(-50deg) scale(1);
+            }
+
+            .readonly:not(.checked) & {
+                &:after {
+                    opacity: 0;
+                    transform: rotate(-30deg) scale(0);
+                }
             }
         }
     }
@@ -80,6 +97,10 @@
         padding-left: $checkbox-width * 1.5;
         vertical-align: middle;
         cursor: pointer;
+
+        .readonly & {
+          cursor: default;
+        }
 
         &:before,
         &:after {
@@ -127,6 +148,16 @@
     #### Selected Checkbox
     ```jsx
     <ZrCheckbox label="Label Here" value="2" id="check2" selected></ZrCheckbox>
+    ```
+
+    #### Readonly Selected Checkbox
+    ```jsx
+    <ZrCheckbox label="Readonly Selected" selected value="3" id="check3" readonly></ZrCheckbox>
+    ```
+
+    #### Readonly Unselected Checkbox
+    ```jsx
+    <ZrCheckbox label="Readonly Unselected" value="4" id="check4" readonly></ZrCheckbox>
     ```
 </docs>
 

--- a/packages/vue/index/components/base/ZrCheckbox.vue
+++ b/packages/vue/index/components/base/ZrCheckbox.vue
@@ -5,7 +5,7 @@
                :id="id"
                :value="value"
                :checked="selected"
-               @change="inputChanged($event)"
+               @click="inputChanged($event)"
                v-bind="$attrs"
                :disabled="disabled"
                :readonly="readonly"
@@ -47,6 +47,8 @@
         if (!this.readonly) {
           this.$emit('change', this.value);
           this.$emit('changeEvent', $event);
+        } else {
+          $event.preventDefault();
         }
       }
     }

--- a/packages/vue/index/mixins/inputShared.js
+++ b/packages/vue/index/mixins/inputShared.js
@@ -76,8 +76,14 @@ export const inputShared = {
     disabled: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Whether the input is or not
+     */
+    readonly: {
+      type: Boolean,
+      default: false
     }
-
   },
   mounted: function() {
     if (this.validationMessage) {


### PR DESCRIPTION
### SUMMARY

This pr adds a readonly prop to the sharedInputs. Updates logic and styles on checkbox component to render and function as if default readonly property was added to native checkbox element.

### SCREENSHOTS

<img width="1066" alt="Screen Shot 2020-09-21 at 3 57 37 PM" src="https://user-images.githubusercontent.com/8801287/93825812-3a46e100-fc23-11ea-96fa-19db3d98d69a.png">
