### PR TITLE
Making the counter value prop dynamic if it changes

### DIFF
--- a/packages/vue/index/components/base/ZrCounter.vue
+++ b/packages/vue/index/components/base/ZrCounter.vue
@@ -87,8 +87,13 @@
         return newCount;
       }
     },
-    beforeMount() {
-      this.count = this.checkAgainstMaxAndMin(this.value, this.min, this.max);
+    watch: {
+      value: {
+        immediate: true,
+        handler: function() {
+          this.count = this.checkAgainstMaxAndMin(this.value, this.min, this.max);
+        }
+      }
     }
   }
 </script>
@@ -176,5 +181,12 @@
   ### Counter with min and max
   ```jsx
   <ZrCounter :min="4" :max="11"></ZrCounter>
+  ```
+
+  ### Dynamic Value
+  ```jsx
+  const value = 3;
+  <button @click="value++">Increment Value</button>
+  <ZrCounter :value="value"></ZrCounter>
   ```
 </docs>


### PR DESCRIPTION
Before the BaseCounter initialized the default count display on the `beforeMount` hook, but if the `value` prop ever updated, it wouldn't propagate through to the view layer.  This refactors that logic so that anytime the `value` prop changes, it updates the actual count on the counter.

This alleviates a current cart bug in BD.