### PR TITLE
UI - Autofocus Prop For Form Elements

### DIFF
--- a/packages/vue/index/components/base/ZrButton.vue
+++ b/packages/vue/index/components/base/ZrButton.vue
@@ -129,7 +129,7 @@
         default: false
       },
       /**
-       * Whether the input should be autofocused
+       * Whether the button should be autofocused
        */
       autofocus: {
         type: Boolean,

--- a/packages/vue/index/components/base/ZrButton.vue
+++ b/packages/vue/index/components/base/ZrButton.vue
@@ -5,7 +5,8 @@
             :type="type"
             v-bind="btnLinkProps"
             :title="title"
-            :disabled="disabled">
+            :disabled="disabled"
+            :autofocus="autofocus">
         <span class="label">
             <slot></slot>
         </span>
@@ -124,6 +125,13 @@
        * Whether to render a div element or not
        */
       renderDiv: {
+        type: Boolean,
+        default: false
+      },
+      /**
+       * Whether the input should be autofocused
+       */
+      autofocus: {
         type: Boolean,
         default: false
       }

--- a/packages/vue/index/components/base/ZrCheckbox.vue
+++ b/packages/vue/index/components/base/ZrCheckbox.vue
@@ -9,6 +9,7 @@
                v-bind="$attrs"
                :disabled="disabled"
                :readonly="readonly"
+               :autofocus="autofocus"
         />
         <label :for="id">{{label}}</label>
     </div>

--- a/packages/vue/index/components/base/ZrInput.vue
+++ b/packages/vue/index/components/base/ZrInput.vue
@@ -15,6 +15,7 @@
            @input="updateValue"
            @blur="$emit('blur')"
            @focus="$emit('focus')"
+           :autofocus="autofocus"
     />
   </base-input-wrapper>
 </template>

--- a/packages/vue/index/components/base/ZrRadio.vue
+++ b/packages/vue/index/components/base/ZrRadio.vue
@@ -8,6 +8,7 @@
            @change="inputChanged"
            v-bind="$attrs"
            :disabled="disabled"
+           :autofocus="autofocus"
     />
     <label :for="id">{{label}}</label>
 </div>
@@ -126,6 +127,11 @@
     #### Selected Radio
     ```jsx
     <ZrRadio label="Label Here" value="2" id="radio2" selected></ZrRadio>
+    ```
+
+    #### AutoFocus Radio
+    ```jsx
+    <ZrRadio label="Label Here" value="2" id="radio3" :autofocus="true"></ZrRadio>
     ```
 </docs>
 

--- a/packages/vue/index/components/base/ZrSelect.vue
+++ b/packages/vue/index/components/base/ZrSelect.vue
@@ -8,7 +8,8 @@
               :class="{'input-sm': size === 'sm', 'input-lg': size === 'lg'}"
               :required="required"
               @change="updateValue"
-              :disabled="disabled">
+              :disabled="disabled"
+              :autofocus="autofocus">
         <option v-if="placeholder" value="" disabled selected>{{placeholder}}</option>
         <option v-for="option of options"
                 :value="option.value"

--- a/packages/vue/index/mixins/inputShared.js
+++ b/packages/vue/index/mixins/inputShared.js
@@ -83,6 +83,13 @@ export const inputShared = {
     readonly: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Whether the input should be autofocused
+     */
+    autofocus: {
+      type: Boolean,
+      default: false
     }
   },
   mounted: function() {


### PR DESCRIPTION
### SUMMARY 

PR adds the autofocus prop to form elements (E.C. buttons, checkboxes, inputs, selects).