### PR TITLE
Introduce browser-default focus outlines for checkboxes.

### DIFF
--- a/packages/vue/index/components/base/ZrCheckbox.vue
+++ b/packages/vue/index/components/base/ZrCheckbox.vue
@@ -89,6 +89,11 @@
                 }
             }
         }
+
+        &:focus + label::before {
+            outline: 1px dotted #212121;
+            outline: 5px auto -webkit-focus-ring-color;
+        }
     }
 
     label {
@@ -161,6 +166,16 @@
     #### Readonly Unselected Checkbox
     ```jsx
     <ZrCheckbox label="Readonly Unselected" value="4" id="check4" readonly></ZrCheckbox>
+    ```
+
+    #### Group of checkboxes
+    ```jsx
+        <fieldset>
+          <legend>Group of Checkboxes</legend>
+          <ZrCheckbox label="First Option" name="checkboxExampleGroup" id="groupOpt1"></ZrCheckbox>
+          <ZrCheckbox label="Second Option" name="checkboxExampleGroup" id="groupOpt2"></ZrCheckbox>
+          <ZrCheckbox label="Third Option" name="checkboxExampleGroup" id="groupOpt3"></ZrCheckbox>
+        </fieldset>
     ```
 </docs>
 

--- a/packages/vue/index/components/base/ZrInput.vue
+++ b/packages/vue/index/components/base/ZrInput.vue
@@ -1,6 +1,6 @@
 <template>
   <base-input-wrapper v-bind="$props" class="zr-input">
-    <label v-if="label" :class="{'visually-hidden': labelHidden}" :for="id">{{label}}</label>
+    <label v-if="label" :class="{'hidden': labelHidden}" :for="id">{{label}}</label>
     <input :type="type"
            :id="id"
            :name="name ? name : id"
@@ -152,7 +152,7 @@
       @include font-label();
       line-height: 1rem;
 
-      &.visually-hidden {
+      &.hidden {
         display: none;
       }
     }

--- a/packages/vue/index/components/base/ZrRangeSlider.vue
+++ b/packages/vue/index/components/base/ZrRangeSlider.vue
@@ -303,16 +303,6 @@
     height: 34px; /* thumb height + label font size */
     position: relative;
 
-    .visually-hidden {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      margin: -1px;
-      padding: 0;
-      overflow: hidden;
-      border: 0;
-    }
-
     /* track styling */
     input[type="range"] {
       width: 100%;

--- a/packages/vue/index/components/base/ZrSelect.vue
+++ b/packages/vue/index/components/base/ZrSelect.vue
@@ -113,15 +113,6 @@
   }
 
   .zr-select {
-    .visually-hidden {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      margin: -1px;
-      padding: 0;
-      overflow: hidden;
-      border: 0;
-    }
     select {
       display: block;
       appearance: none;

--- a/packages/vue/index/styles/imports.scss
+++ b/packages/vue/index/styles/imports.scss
@@ -1,2 +1,3 @@
 @import './variables/variables';
 @import './mixins/mixins';
+@import 'utility/utility';

--- a/packages/vue/index/styles/utility/utility.scss
+++ b/packages/vue/index/styles/utility/utility.scss
@@ -1,0 +1,9 @@
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+}


### PR DESCRIPTION
Custom styling on the checkbox component did not include a focus outline. This has been added in. The focus outline applied is very similar to the browser default focus outline on unstyled checkboxes.

Browser default:
![0ss 2021-11-30 at 2 12 22 PM](https://user-images.githubusercontent.com/12087976/144132581-b5047980-0ee5-4ad5-addf-8ebbfe00d5a8.jpg)

New style on custom styled checkboxes:
![0ss 2021-11-30 at 2 12 07 PM](https://user-images.githubusercontent.com/12087976/144132617-7d333d97-a3f0-4add-89eb-cc8ea6402cdf.jpg)

